### PR TITLE
Make fixes to code per AWS deployment problems

### DIFF
--- a/app-credentials-layout.json
+++ b/app-credentials-layout.json
@@ -5,6 +5,7 @@
     "sftp_host": null,
     "sftp_username": null,
     "sftp_password": null,
-    "sftp_port": 22
+    "sftp_port": 22,
+    "bucket_name": null
   }
 ]

--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ SOURCE_CONNECTION = "s3"
 CREDENTIALS_PATH = "./app-credentials.json"
 
 # Path to WordPress files gallery
-GALLERY_PATH = "public_html/wp-content/gallery"
+GALLERY_PATH = None  # an example would be "public_html/wp-content/gallery" - to keep it in the base bucket put `None`
 
 # Acceptable image file formats to look for in Slack Event
 ACCEPTABLE_FILE_FORMATS = [

--- a/file_navigator/s3_file_navigator/s3_navigator.py
+++ b/file_navigator/s3_file_navigator/s3_navigator.py
@@ -14,6 +14,7 @@ class S3Navigator(FileNavigatorBase):
     def s3_resource(self):
         if self._s3_resource is None:
             self._s3_resource = boto3.resource("s3")
+            print("Connected to S3 resource.")
         return self._s3_resource
 
     @property

--- a/file_navigator/s3_file_navigator/s3_navigator.py
+++ b/file_navigator/s3_file_navigator/s3_navigator.py
@@ -5,7 +5,7 @@ from file_navigator import FileNavigatorBase
 
 class S3Navigator(FileNavigatorBase):
 
-    def __init__(self, bucket_name):
+    def __init__(self, bucket_name, **kwargs):
         self._s3_resource = None
         self._s3_bucket = None
         self.bucket_name = bucket_name

--- a/file_navigator/sftp_file_navigator/sftp_navigator.py
+++ b/file_navigator/sftp_file_navigator/sftp_navigator.py
@@ -13,7 +13,7 @@ class SFTPNavigator(FileNavigatorBase):
 
     DEFAULT_CUTOFF_TIME_IN_SECONDS = 60 * 60 * 24 * 365  # about a year
 
-    def __init__(self, host=None, username=None, password=None, port=None, sftp_connector=SFTPConnector()):
+    def __init__(self, host=None, username=None, password=None, port=None, sftp_connector=SFTPConnector(), **kwargs):
         self._host = host
         self._username = username
         self._password = password

--- a/slack_api/event_handler_factory.py
+++ b/slack_api/event_handler_factory.py
@@ -18,7 +18,7 @@ class EventHandlerFactory:
         """
         storage_navigator_class = self.CONNECTION_MAP[SOURCE_CONNECTION]
         storage_navigator = storage_navigator_class(**credentials)
-        slack_api_requester = SlackApiRequester(bot_token=credentials["bot_token"])
+        slack_api_requester = SlackApiRequester(bot_token=credentials["slack_bot_token"])
 
         handler = SlackEventApiHandler(
             file_storage_navigator=storage_navigator,

--- a/slack_api/slack_event_api_handler.py
+++ b/slack_api/slack_event_api_handler.py
@@ -113,4 +113,4 @@ class SlackEventApiHandler:
             self.storage_navigator.save_file_to_directory(image_data, f"{directory_path}/{image_name}")
 
         except Exception as err:
-            print(f"An SFTP Error occurred: {err}")
+            print(f"An error occurred when saving the file: {err}")

--- a/slack_api/slack_event_api_handler.py
+++ b/slack_api/slack_event_api_handler.py
@@ -20,6 +20,7 @@ class SlackEventApiHandler:
 
     SUCCESSFUL_CHALLENGE_MESSAGE = "A valid challenge received."
     FAILED_CHALLENGE_MESSAGE = "Did not receive a valid challenge."
+    GALLERY_PATH = GALLERY_PATH
 
     def __init__(
             self,
@@ -106,7 +107,7 @@ class SlackEventApiHandler:
 
     def _save_image_to_file(self, image_data, image_name, channel_name):
         try:
-            directory_path = f"{GALLERY_PATH}/{channel_name}"
+            directory_path = f"{self.GALLERY_PATH}/{channel_name}" if self.GALLERY_PATH else channel_name
             if self.storage_navigator.is_file_in_directory(directory_path, image_name):
                 raise FileAlreadyExistsError(Err.FILE_EXISTS)
 

--- a/tests/test_slack_event_api_handler.py
+++ b/tests/test_slack_event_api_handler.py
@@ -38,6 +38,8 @@ fake_event_data = {
 }
 image_data = b"this_is_the_image_data"
 
+FAKE_GALLERY_PATH = "wp-content/gallery"
+
 
 def create_fake_challenge_response(token=None, challenge=None) -> dict:
     if not token and not challenge:
@@ -102,11 +104,21 @@ class TestSlackEventApiHandler(TestCase):
 
         self.mock_requester.get_image_data.assert_called_once_with(image_url)
 
-    def test_handle_slack_event__file_shared_event__makes_expected_request_to_save_image_to_file(self):
+    def test_handle_slack_event__file_shared_event__gallery_path_present__makes_expected_request_to_save_image_to_file(self):
         self.fake_file_data = fake_file_data
+        self.api_handler.GALLERY_PATH = FAKE_GALLERY_PATH  # I know this is monkey patching of the config setting
         self.api_handler.handle_slack_event(fake_event_data)
 
-        expected_request = image_data, f"{GALLERY_PATH}/{channel_name}/{image_name}"
+        expected_request = image_data, f"{FAKE_GALLERY_PATH}/{channel_name}/{image_name}"
+
+        self.mock_navigator.save_file_to_directory.assert_called_once_with(*expected_request)
+
+    def test_handle_slack_event__file_shared_event__no_gallery_path__makes_expected_request_to_save_image_to_file(self):
+        self.fake_file_data = fake_file_data
+        self.api_handler.GALLERY_PATH = None  # I know this is monkey patching of the config setting
+        self.api_handler.handle_slack_event(fake_event_data)
+
+        expected_request = image_data, f"{channel_name}/{image_name}"
 
         self.mock_navigator.save_file_to_directory.assert_called_once_with(*expected_request)
 


### PR DESCRIPTION
* modified config file (e.g. GALLERY_PATH)
* navigators now accept values upon instantiation that they don't directly use
* fixed key error from credentials for SLACK_BOT_TOKEN
* updated keys in credentials file
* tests pass
* Because of how AWS saves files, I had to implement a different way to modify the path in the S3 Bucket