### PR TITLE
Filter threaded files

### DIFF
--- a/callback_functions/slack_events_receive_callback.py
+++ b/callback_functions/slack_events_receive_callback.py
@@ -39,7 +39,7 @@ def slack_events_receive_callback(request) -> dict:
     else:
         response = {"message": "Received no event type."}
 
-    return response
+    return {"statusCode": 200, "body": response}
 
 
 def is_request_timestamp_valid(timestamp):

--- a/config.py
+++ b/config.py
@@ -4,6 +4,9 @@ SOURCE_CONNECTION = "s3"
 # Path to credential JSON file within application
 CREDENTIALS_PATH = "./app-credentials.json"
 
+# Set to False if you want to include images sent in Slack message threads (replies)
+EXCLUDE_THREADED_IMAGES = True
+
 # Path to WordPress files gallery
 GALLERY_PATH = None  # an example would be "public_html/wp-content/gallery" - to keep it in the base bucket put `None`
 

--- a/slack_api/slack_event_api_handler.py
+++ b/slack_api/slack_event_api_handler.py
@@ -1,4 +1,4 @@
-from config import GALLERY_PATH, ACCEPTABLE_FILE_FORMATS
+from config import GALLERY_PATH, ACCEPTABLE_FILE_FORMATS, EXCLUDE_THREADED_IMAGES
 from utils.specified_exceptions import (
     ErrorMessages as Err,
     UnexpectedEventTypeError,
@@ -63,6 +63,11 @@ class SlackEventApiHandler:
         file_channel_id = file_event_data["event"]["channel_id"]
 
         file_data = self._get_file_data_from_slack(file_id, file_channel_id)
+
+        if EXCLUDE_THREADED_IMAGES:
+            is_thread = file_data["file"]["shares"]["public"][file_channel_id][0].get("thread_ts", False)
+            if is_thread:
+                return None
 
         file_name = file_data["file"]["name"]
         channel_name = file_data["file"]["shares"]["public"][file_channel_id][0]["channel_name"]

--- a/slack_api/slack_event_api_handler.py
+++ b/slack_api/slack_event_api_handler.py
@@ -1,4 +1,8 @@
-from config import GALLERY_PATH, ACCEPTABLE_FILE_FORMATS, EXCLUDE_THREADED_IMAGES
+from config import (
+    GALLERY_PATH,
+    ACCEPTABLE_FILE_FORMATS,
+    EXCLUDE_THREADED_IMAGES
+)
 from utils.specified_exceptions import (
     ErrorMessages as Err,
     UnexpectedEventTypeError,
@@ -20,7 +24,6 @@ class SlackEventApiHandler:
 
     SUCCESSFUL_CHALLENGE_MESSAGE = "A valid challenge received."
     FAILED_CHALLENGE_MESSAGE = "Did not receive a valid challenge."
-    GALLERY_PATH = GALLERY_PATH
 
     def __init__(
             self,
@@ -112,7 +115,7 @@ class SlackEventApiHandler:
 
     def _save_image_to_file(self, image_data, image_name, channel_name):
         try:
-            directory_path = f"{self.GALLERY_PATH}/{channel_name}" if self.GALLERY_PATH else channel_name
+            directory_path = f"{GALLERY_PATH}/{channel_name}" if GALLERY_PATH else channel_name
             if self.storage_navigator.is_file_in_directory(directory_path, image_name):
                 raise FileAlreadyExistsError(Err.FILE_EXISTS)
 

--- a/tests/test_slack_event_api_handler.py
+++ b/tests/test_slack_event_api_handler.py
@@ -1,10 +1,13 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
-from config import GALLERY_PATH
 from slack_api.slack_event_api_handler import SlackEventApiHandler
-from utils.specified_exceptions import UnexpectedEventTypeError, SlackApiError, FileFormatError, \
+from utils.specified_exceptions import (
+    UnexpectedEventTypeError,
+    SlackApiError,
+    FileFormatError,
     WrongChannelProvidedError
+)
 
 file_id = "12345"
 channel_id = "6789"
@@ -120,18 +123,18 @@ class TestSlackEventApiHandler(TestCase):
 
         self.mock_requester.get_image_data.assert_called_once_with(image_url)
 
+    @patch("slack_api.slack_event_api_handler.GALLERY_PATH", new=FAKE_GALLERY_PATH)
     def test_handle_slack_event__file_shared_event__gallery_path_present__makes_expected_request_to_save_image_to_file(self):
         self.fake_file_data = fake_file_data
-        self.api_handler.GALLERY_PATH = FAKE_GALLERY_PATH  # I know this is monkey patching of the config setting
         self.api_handler.handle_slack_event(fake_event_data)
 
         expected_request = image_data, f"{FAKE_GALLERY_PATH}/{channel_name}/{image_name}"
 
         self.mock_navigator.save_file_to_directory.assert_called_once_with(*expected_request)
 
+    @patch("slack_api.slack_event_api_handler.GALLERY_PATH", new=None)
     def test_handle_slack_event__file_shared_event__no_gallery_path__makes_expected_request_to_save_image_to_file(self):
         self.fake_file_data = fake_file_data
-        self.api_handler.GALLERY_PATH = None  # I know this is monkey patching of the config setting
         self.api_handler.handle_slack_event(fake_event_data)
 
         expected_request = image_data, f"{channel_name}/{image_name}"


### PR DESCRIPTION
* Files from threads (message replies) can now be distinguished from and filtered out of images that are pulled from slack events

Minor Changes:
* Resolved monkey patching in tests
* Defined callback return value to 200